### PR TITLE
Fix for outputs.upToDateWhen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle-experimental:0.8.1'
+        classpath 'com.android.tools.build:gradle-experimental:0.9.0-beta2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -25,21 +25,3 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
-
-// The dependencies for NDK builds live inside the .aar files so they need to
-// be extracted before NDK targets can build.
-task extractAudioSo(type: Copy) {
-    from zipTree("${project.rootDir}/libraries/sdk-audio-1.20.0.aar")
-    into "${project.rootDir}/libraries/"
-    include "jni/**/libgvr_audio.so"
-}
-
-task extractGvrSo(type: Copy) {
-    from zipTree("${project.rootDir}/libraries/sdk-base-1.20.0.aar")
-    into "${project.rootDir}/libraries/"
-    include "jni/**/libgvr.so"
-}
-
-task extractNdk { }
-extractNdk.dependsOn extractAudioSo
-extractNdk.dependsOn extractGvrSo

--- a/samples/ndk-controllerpaint/build.gradle
+++ b/samples/ndk-controllerpaint/build.gradle
@@ -56,4 +56,44 @@ dependencies {
     compile 'com.google.vr:sdk-base:1.20.0'
 }
 
-build.dependsOn(':extractNdk')
+import java.security.MessageDigest
+
+static def generateMD5(File file){
+    MessageDigest.getInstance("MD5").digest(file.bytes).encodeHex().toString();
+}
+
+// The dependencies for NDK builds live inside the .aar files so they need to
+// be extracted before NDK targets can build.
+task extractGoogleVrNDK {
+    outputs.upToDateWhen {
+        if(new File("${project.rootDir}/Libraries/MD5SUM.properties").exists()) {
+            Properties props = new Properties();
+            props.load(new FileInputStream("${project.rootDir}/Libraries/MD5SUM.properties"));
+            return props.getProperty("MD5") == generateMD5(new File(props.getProperty("file")))
+        }
+        return false;
+    }
+    doLast {
+        def outFile = new File("${project.rootDir}/Libraries/MD5SUM.properties")
+        String outString = new String();
+        configurations.compile.each {
+            if (it.name.contains("sdk-base") || it.name.contains("sdk-audio")) {
+                def file = it.absoluteFile
+                copy {
+                    from zipTree(file)
+                    into "${project.rootDir}/Libraries"
+                    include "jni/**/libgvr*.so"
+                }
+                outString = "file = " + file.absolutePath + "\n"
+                outString += "MD5 = " + generateMD5(file) + "\n"
+            }
+        }
+        outFile.write(outString)
+    }
+}
+
+tasks.whenTaskAdded { task ->
+    if (task.name.startsWith('generate')) {
+        task.dependsOn extractGoogleVrNDK
+    }
+}

--- a/samples/ndk-treasurehunt/build.gradle
+++ b/samples/ndk-treasurehunt/build.gradle
@@ -58,4 +58,46 @@ dependencies {
     compile 'com.google.vr:sdk-base:1.20.0'
 }
 
-build.dependsOn(':extractNdk')
+import java.security.MessageDigest
+
+static def generateMD5(File file){
+    MessageDigest.getInstance("MD5").digest(file.bytes).encodeHex().toString();
+}
+
+// The dependencies for NDK builds live inside the .aar files so they need to
+// be extracted before NDK targets can build.
+task extractGoogleVrNDK {
+    outputs.upToDateWhen {
+        if(new File("${project.rootDir}/Libraries/MD5SUM.properties").exists()) {
+            Properties props = new Properties();
+            props.load(new FileInputStream("${project.rootDir}/Libraries/MD5SUM.properties"));
+            return props.getProperty("MD5") == generateMD5(new File(props.getProperty("file")))
+        }
+        else {
+            return false
+        }
+    }
+    doLast {
+        def outFile = new File("${project.rootDir}/Libraries/MD5SUM.properties")
+        String outString = new String();
+        configurations.compile.each {
+            if (it.name.contains("sdk-base") || it.name.contains("sdk-audio")) {
+                def file = it.absoluteFile
+                copy {
+                    from zipTree(file)
+                    into "${project.rootDir}/Libraries"
+                    include "jni/**/libgvr*.so"
+                }
+                outString = "file = " + file.absolutePath + "\n"
+                outString += "MD5 = " + generateMD5(file) + "\n"
+            }
+        }
+        outFile.write(outString)
+    }
+}
+
+tasks.whenTaskAdded { task ->
+    if (task.name.startsWith('generate')) {
+        task.dependsOn extractGoogleVrNDK
+    }
+}


### PR DESCRIPTION
This introduces two things.
1.) use the maven downloaded aar instead of the aar in the libraries folder.  This makes it so java library used is same as the one that produces the so library file and takes away the requirement of devs downloading the SDK at all.
2.) test if the libraries need to be re generated from the aar.  This should make it so it is impossible to have the java aar different than the one that the so files are linking against.